### PR TITLE
Fix warning about SPDX-formatted licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/hotosm/oam-uploader-api.git"
   },
   "author": "Development Seed",
-  "license": "BSD 3-Clause",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/hotosm/oam-uploader-api/issues"
   },


### PR DESCRIPTION
Emitted when running `npm install`:

```
npm WARN package.json oam-uploader-api@1.0.0 license should be a valid SPDX license expression
```