### PR TITLE
Extract server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+web: npm start

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The steps below will walk you through setting up your own instance of the oam-up
 
 #### Starting the API:
 
-    $ node index.js
+    $ npm start
 
 The API exposes endpoints used to access information form the system via a RESTful interface.
 

--- a/index.js
+++ b/index.js
@@ -72,21 +72,4 @@ var OAMUploader = function (readyCb) {
   });
 };
 
-// https://medium.com/the-spumko-suite/testing-hapi-services-with-lab-96ac463c490a
-// The if (!module.parent) {…} conditional makes sure that if the script is
-// being required as a module by another script, we don’t start the server.
-// This is done to prevent the server from starting when we’re testing it.
-// With Hapi, we don’t need to have the server listening to test it.
-if (!module.parent) {
-  OAMUploader(function (hapi) {
-    // Start the server.
-    hapi.start(function () {
-      hapi.log(['info'], 'Server running at:' + hapi.info.uri);
-      // spawn a worker to handle any unprocessed uploads that may be sitting
-      // around in the database
-      hapi.plugins.workers.spawn();
-    });
-  });
-}
-
 module.exports = OAMUploader;

--- a/package.json
+++ b/package.json
@@ -2,14 +2,12 @@
   "name": "oam-uploader-api",
   "version": "1.0.0",
   "description": "An uploader API for Open Aerial Map Imagery",
-  "main": "index.js",
   "scripts": {
     "docker-build": "docker build -t oam-uploader-api .build_scripts/docker",
     "docker-install": ".build_scripts/docker/run.sh /install.sh",
     "docker-test": ".build_scripts/docker/run.sh /test.sh",
     "docker-start": ".build_scripts/docker/run.sh /start.sh",
     "docker-console": ".build_scripts/docker/run.sh bash",
-    "start": "TMPDIR=/tmp node index.js",
     "test": "semistandard && npm run lab",
     "lab": "lab -T test/babel.js test/test__*.js",
     "docs": "apidoc -i routes/ -o docs/"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,11 @@
+var OAMUploader = require('./');
+
+OAMUploader(function (hapi) {
+  // Start the server.
+  hapi.start(function () {
+    hapi.log(['info'], 'Server running at:' + hapi.info.uri);
+    // spawn a worker to handle any unprocessed uploads that may be sitting
+    // around in the database
+    hapi.plugins.workers.spawn();
+  });
+});


### PR DESCRIPTION
This allows the module to follow default Node conventions where `index.js` contains default exports and `npm start` runs `node server.js`.