### PR TITLE
adjust for temp bucket

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ var defaults = {
   adminPassword: null, // the administrator username
   adminUsername: null, // the administrator password
   oinBucket: 'oam-uploader', // name of the OpenImageryNetwork bucket to which imagery should be uploaded
+  uploadBucket: 'oam-uploader-temp', // name of the bucket for temporary storage for direct uploads
   thumbnailSize: 300, // (very) approximate thumbnail size, in kilobytes
   maxWorkers: 1, // the maximum number of workers
   sendgridApiKey: null, // sendgrid API key, for sending notification emails
@@ -42,6 +43,7 @@ var environment = {
   port: process.env.PORT,
   host: process.env.HOST,
   oinBucket: process.env.OIN_BUCKET,
+  uploadBucket: process.env.UPLOAD_BUCKET,
   dbUri: process.env.NODE_ENV === 'test' ? process.env.DBURI_TEST : process.env.DBURI,
   maxWorkers: process.env.MAX_WORKERS,
   adminPassword: process.env.ADMIN_PASSWORD,

--- a/local.sample.env
+++ b/local.sample.env
@@ -9,6 +9,7 @@ export SENDGRID_API_KEY=<your-sendgrid-key>
 export SENDGRID_FROM=<emailaccount@that.sends.notifications.com>
 
 export OIN_BUCKET=oam-uploader
+export UPLOAD_BUCKET=oam-uploader-temp
 
 export DBURI=mongodb://localhost/oam-uploader
 export DBURI_TEST=mongodb://localhost/oam-uploader-test

--- a/routes/uploads.js
+++ b/routes/uploads.js
@@ -99,7 +99,7 @@ module.exports = [
       var payload = JSON.parse(request.payload);
       var s3 = new AWS.S3();
       var params = {
-        Bucket: config.oinBucket,
+        Bucket: config.uploadBucket,
         Key: payload.name,
         ContentType: payload.type,
         Expires: 60


### PR DESCRIPTION
PR into the current `uploads` branch to make adjustments for storing imagery in a temp bucket from direct uploads. This factors for erroneous imagery that is uploaded. Instead of uploading directly to the OIN bucket, it goes to a temp bucket before it is then processed. The temp bucket can then be clear periodically to keep storage costs low. 

Matching changes made on the [frontend Uploader](https://github.com/hotosm/oam-uploader). 

This was tested and works. 👍 

@nbumbarger @danielfdsilva Can you double check the changes before we merge this into the current `uploads` branch? 