### PR TITLE
fix validation check for empty tags

### DIFF
--- a/models/upload.js
+++ b/models/upload.js
@@ -15,7 +15,7 @@ var sceneSchema = Joi.object().keys({
   acquisition_end: Joi.date().required(),
   tms: Joi.string().allow(null),
   license: Joi.string().required(),
-  tags: Joi.string().allow(null),
+  tags: Joi.string().allow(''),
   urls: Joi.array().items(Joi.string().uri({scheme: ['http', 'https', 'gdrive']}))
     .min(1).required()
 });


### PR DESCRIPTION
PR to change the validation check for tags. Upon testing the tags addition, validation errors were happening within the API. 

```
"name":"ValidationError","details":[{"message":"\"tags\" is not allowed to be empty"
```

Changing to empty string instead of null seems to fix the validation. 