### PR TITLE
Mount /tmp from the host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,5 @@ services:
       - "4000:4000"
     depends_on:
       - mongo
+    volumes:
+      - /tmp/uploader-api:/tmp


### PR DESCRIPTION
This increases the amount of available temp space from 10GB (default root volume size) to whatever the partition that /tmp is on has free.